### PR TITLE
Add push constant support

### DIFF
--- a/Mtgp.Proxy.Console/ShaderModeExtension.cs
+++ b/Mtgp.Proxy.Console/ShaderModeExtension.cs
@@ -76,8 +76,9 @@ internal class ShaderModeExtension(ILogger<ShaderModeExtension> logger, TelnetCo
 		proxy.RegisterMessageHandler<AddCopyBufferToImageActionRequest>(AddCopyBufferToImageAction);
 		proxy.RegisterMessageHandler<AddCopyBufferActionRequest>(AddCopyBufferAction);
 		proxy.RegisterMessageHandler<AddClearBufferActionRequest>(AddClearBufferAction);
-		proxy.RegisterMessageHandler<AddBindVertexBuffersRequest>(AddBindVertexBuffers);
-		proxy.RegisterMessageHandler<AddDrawActionRequest>(AddDrawAction);
+                proxy.RegisterMessageHandler<AddBindVertexBuffersRequest>(AddBindVertexBuffers);
+                proxy.RegisterMessageHandler<AddPushConstantsActionRequest>(AddPushConstantsAction);
+                proxy.RegisterMessageHandler<AddDrawActionRequest>(AddDrawAction);
 		proxy.RegisterMessageHandler<AddDispatchActionRequest>(AddDispatchAction);
 		proxy.RegisterMessageHandler<AddIndirectDrawActionRequest>(AddIndirectDrawAction);
 		proxy.RegisterMessageHandler<AddPresentActionRequest>(AddPresentAction);
@@ -298,14 +299,23 @@ internal class ShaderModeExtension(ILogger<ShaderModeExtension> logger, TelnetCo
 		return new MtgpResponse(0, "ok");
 	}
 
-	private MtgpResponse AddBindVertexBuffers(AddBindVertexBuffersRequest request)
-	{
-		var actionList = this.resourceStore.Get<ActionListInfo>(request.ActionList).Actions;
+        private MtgpResponse AddBindVertexBuffers(AddBindVertexBuffersRequest request)
+        {
+                var actionList = this.resourceStore.Get<ActionListInfo>(request.ActionList).Actions;
 
-		actionList.Add(new BindVertexBuffersAction(request.FirstBufferIndex, request.Buffers.Select(x => (this.resourceStore.Get<BufferInfo>(x.BufferIndex).Data, x.Offset)).ToArray()));
+                actionList.Add(new BindVertexBuffersAction(request.FirstBufferIndex, request.Buffers.Select(x => (this.resourceStore.Get<BufferInfo>(x.BufferIndex).Data, x.Offset)).ToArray()));
 
-		return new MtgpResponse(0, "ok");
-	}
+                return new MtgpResponse(0, "ok");
+        }
+
+        private MtgpResponse AddPushConstantsAction(AddPushConstantsActionRequest request)
+        {
+                var actionList = this.resourceStore.Get<ActionListInfo>(request.ActionList).Actions;
+
+                actionList.Add(new SetPushConstantsAction(request.Data));
+
+                return new MtgpResponse(0, "ok");
+        }
 
 	private MtgpResponse AddClearBufferAction(AddClearBufferActionRequest request)
 	{

--- a/Mtgp.Proxy.Shader.Tests/ShaderTestsBase.cs
+++ b/Mtgp.Proxy.Shader.Tests/ShaderTestsBase.cs
@@ -30,7 +30,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], default, outputData);
+                        target.Execute([], [], default, default, outputData);
 
 			new BitReader(outputMappings.GetBuiltin(outputData, Builtin.PositionX)).Read(out int outputValue);
 
@@ -61,7 +61,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], default, outputData);
+                        target.Execute([], [], default, default, outputData);
 
 			new BitReader(outputMappings.GetBuiltin(outputData, Builtin.PositionY)).Read(out int outputValue);
 
@@ -92,7 +92,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], default, outputData);
+                        target.Execute([], [], default, default, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, location)).Read(out int outputValue);
 
@@ -129,7 +129,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+                        target.Execute([], [], default, default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -172,7 +172,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+                        target.Execute([], [], default, default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out float outputValue);
 
@@ -217,7 +217,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+                        target.Execute([], [], default, default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -259,7 +259,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -296,7 +296,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[16];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 2)).Read(out int outputValue);
 
@@ -338,7 +338,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -380,7 +380,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out float outputValue);
 
@@ -410,7 +410,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			var uniformBinding = new byte[4];
 
-            target.Execute([], [uniformBinding], default, default);
+            target.Execute([], [uniformBinding], default, default, default);
 
             new BitReader(uniformBinding).Read(out int actual);
             actual.Should().Be(123);
@@ -448,7 +448,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [uniformBinding], default, outputData);
+                        target.Execute([], [uniformBinding], default, default, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -505,7 +505,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[16];
 
-			target.Execute([], [uniformBinding], default, outputData);
+                        target.Execute([], [uniformBinding], default, default, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0))
 				.Read(out int outputIntValue)
@@ -573,7 +573,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[16];
 
-			target.Execute([], [uniformBinding], default, outputData);
+                        target.Execute([], [uniformBinding], default, default, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0))
 				.Read(out int outputIntValue)
@@ -614,7 +614,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			var uniformBinding = new byte[12];
 
-			target.Execute([], [uniformBinding], default, default);
+                        target.Execute([], [uniformBinding], default, default, default);
 
 			new BitReader(uniformBinding).Read(out int x).Read(out int y).Read(out int z);
 			x.Should().Be(123);
@@ -657,12 +657,13 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			var outputSpan = new byte[outputMappings.Size];
 
-			target.Execute(
-				imageAttachments,
-				[],
-				default,
-				outputSpan
-			);
+                        target.Execute(
+                                imageAttachments,
+                                [],
+                                default,
+                                default,
+                                outputSpan
+                        );
 
 			new BitReader(outputMappings.GetLocation(outputSpan, 0)).Read(out int outputValue);
 
@@ -709,12 +710,13 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			var outputSpan = new byte[outputMappings.Size];
 
-			target.Execute(
-				imageAttachments,
-				[],
-				default,
-				outputSpan
-			);
+                        target.Execute(
+                                imageAttachments,
+                                [],
+                                default,
+                                default,
+                                outputSpan
+                        );
 
 			new BitReader(outputMappings.GetLocation(outputSpan, 0))
 				.Read(out float x)
@@ -762,12 +764,13 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			var outputSpan = new byte[outputMappings.Size];
 
-			target.Execute(
-				imageAttachments,
-				[],
-				default,
-				outputSpan
-			);
+                        target.Execute(
+                                imageAttachments,
+                                [],
+                                default,
+                                default,
+                                outputSpan
+                        );
 
 			new BitReader(outputMappings.GetLocation(outputSpan, 0)).Read(out int outputValue);
 
@@ -801,7 +804,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[4];
 
-			target.Execute([], [], default, outputData);
+			target.Execute([], [], default, default, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -840,7 +843,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[outputMappings.Size];
 
-			target.Execute([], [], [], outputData);
+			target.Execute([], [], default, [], outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -898,7 +901,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[outputMappings.Size];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -956,7 +959,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[outputMappings.Size];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 
@@ -1014,7 +1017,7 @@ namespace Mtgp.Proxy.Shader.Tests
 
 			Span<byte> outputData = stackalloc byte[outputMappings.Size];
 
-			target.Execute([], [], inputData, outputData);
+			target.Execute([], [], default, inputData, outputData);
 
 			new BitReader(outputMappings.GetLocation(outputData, 0)).Read(out int outputValue);
 

--- a/Mtgp.Proxy.Shader/ComputePipeline.cs
+++ b/Mtgp.Proxy.Shader/ComputePipeline.cs
@@ -9,8 +9,8 @@ public class ComputePipeline(ShaderExecutor shader)
 {
 	public static string ResourceType => CreateComputePipelineInfo.ResourceType;
 
-	public void Execute(ILogger logger, Extent3D dimensions, Memory<byte>[] bufferViewAttachments)
-	{
+        public void Execute(ILogger logger, Extent3D dimensions, Memory<byte>[] bufferViewAttachments, Memory<byte> pushConstants)
+        {
 		Span<byte> inputSpan = stackalloc byte[shader.InputMappings.Size];
 
 		for (int x = 0; x < dimensions.Width; x++)
@@ -27,7 +27,7 @@ public class ComputePipeline(ShaderExecutor shader)
 				}
 			}
 
-			shader.Execute([], bufferViewAttachments, inputSpan, []);
+                        shader.Execute([], bufferViewAttachments, pushConstants.Span, inputSpan, []);
 		}
 	}
 }

--- a/Mtgp.Proxy.Shader/DispatchAction.cs
+++ b/Mtgp.Proxy.Shader/DispatchAction.cs
@@ -4,10 +4,10 @@ using Mtgp.Shader;
 namespace Mtgp.Proxy.Shader;
 
 public class DispatchAction(ComputePipeline pipeline, Extent3D dimensions, Memory<byte>[] bufferViewAttachments)
-	: IAction
+        : IAction
 {
-	public void Execute(ILogger logger, ActionExecutionState state)
-	{
-		pipeline.Execute(logger, dimensions, bufferViewAttachments);
-	}
+        public void Execute(ILogger logger, ActionExecutionState state)
+        {
+                pipeline.Execute(logger, dimensions, bufferViewAttachments, state.PushConstants);
+        }
 }

--- a/Mtgp.Proxy.Shader/DrawAction.cs
+++ b/Mtgp.Proxy.Shader/DrawAction.cs
@@ -5,6 +5,6 @@ namespace Mtgp.Proxy.Shader;
 public class DrawAction(RenderPipeline pipeline, ImageState[] imageAttachments, Memory<byte>[] bufferViewAttachments, FrameBuffer frameBuffer, int instanceCount, int vertexCount)
 	: IAction
 {
-	public void Execute(ILogger logger, ActionExecutionState state)
-		=> pipeline.Execute(logger, instanceCount, vertexCount, [.. state.VertexBuffers], imageAttachments, bufferViewAttachments, frameBuffer);
+        public void Execute(ILogger logger, ActionExecutionState state)
+                => pipeline.Execute(logger, instanceCount, vertexCount, [.. state.VertexBuffers], state.PushConstants, imageAttachments, bufferViewAttachments, frameBuffer);
 }

--- a/Mtgp.Proxy.Shader/IAction.cs
+++ b/Mtgp.Proxy.Shader/IAction.cs
@@ -9,6 +9,7 @@ public interface IAction
 
 public class ActionExecutionState
 {
-	public readonly List<(byte[] Buffer, int Offset)> VertexBuffers = [];
-	public required Memory<byte> PipeData { get; init; }
+        public readonly List<(byte[] Buffer, int Offset)> VertexBuffers = [];
+        public required Memory<byte> PipeData { get; init; }
+        public Memory<byte> PushConstants { get; set; } = Memory<byte>.Empty;
 }

--- a/Mtgp.Proxy.Shader/IndirectDrawAction.cs
+++ b/Mtgp.Proxy.Shader/IndirectDrawAction.cs
@@ -10,6 +10,6 @@ public class IndirectDrawAction(RenderPipeline pipeline, ImageState[] imageAttac
 		var instanceCount = BitConverter.ToInt32(buffer.Span[offset..]);
 		var vertexCount = BitConverter.ToInt32(buffer.Span[(offset + 4)..]);
 
-		pipeline.Execute(logger, instanceCount, vertexCount, [.. state.VertexBuffers], imageAttachments, bufferViewAttachments, frameBuffer);
+                pipeline.Execute(logger, instanceCount, vertexCount, [.. state.VertexBuffers], state.PushConstants, imageAttachments, bufferViewAttachments, frameBuffer);
 	}
 }

--- a/Mtgp.Proxy.Shader/RenderPipeline.cs
+++ b/Mtgp.Proxy.Shader/RenderPipeline.cs
@@ -18,7 +18,7 @@ public class RenderPipeline(Dictionary<ShaderStage, ShaderExecutor> shaderStages
 {
 	public static string ResourceType => CreateRenderPipelineInfo.ResourceType;
 
-	public void Execute(ILogger logger, int instanceCount, int vertexCount, (byte[] Buffer, int Offset)[] vertexBuffers, ImageState[] imageAttachments, Memory<byte>[] bufferViewAttachments, FrameBuffer frameBuffer)
+        public void Execute(ILogger logger, int instanceCount, int vertexCount, (byte[] Buffer, int Offset)[] vertexBuffers, Memory<byte> pushConstants, ImageState[] imageAttachments, Memory<byte>[] bufferViewAttachments, FrameBuffer frameBuffer)
 	{
 		int timerValue = Environment.TickCount;
 
@@ -116,7 +116,7 @@ public class RenderPipeline(Dictionary<ShaderStage, ShaderExecutor> shaderStages
 
 					var outputSpan = primitiveSpan[(vertexIndex * vertex.OutputMappings.Size)..][..vertex.OutputMappings.Size];
 
-					vertex.Execute(imageAttachments, bufferViewAttachments, inputSpan, outputSpan);
+                                        vertex.Execute(imageAttachments, bufferViewAttachments, pushConstants.Span, inputSpan, outputSpan);
 				}
 
 				int fromX = BitConverter.ToInt32(vertex.OutputMappings.GetBuiltin(primitiveSpan, Builtin.PositionX, 0));
@@ -264,7 +264,7 @@ public class RenderPipeline(Dictionary<ShaderStage, ShaderExecutor> shaderStages
 
 				var output = new byte[outputSize];
 
-				fragment.Execute(imageAttachments, bufferViewAttachments, fragmentInput, output);
+                                fragment.Execute(imageAttachments, bufferViewAttachments, pushConstants.Span, fragmentInput, output);
 
 				float alpha = 1.0f;
 

--- a/Mtgp.Proxy.Shader/SetPushConstantsAction.cs
+++ b/Mtgp.Proxy.Shader/SetPushConstantsAction.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace Mtgp.Proxy.Shader;
+
+public class SetPushConstantsAction(byte[] data) : IAction
+{
+    private readonly byte[] data = data;
+
+    public void Execute(ILogger logger, ActionExecutionState state)
+    {
+        state.PushConstants = this.data;
+    }
+}

--- a/Mtgp.Proxy.Shader/ShaderExecutor.cs
+++ b/Mtgp.Proxy.Shader/ShaderExecutor.cs
@@ -8,7 +8,7 @@ public abstract class ShaderExecutor
 {
 	public abstract ShaderIoMappings InputMappings { get; }
 	public abstract ShaderIoMappings OutputMappings { get; }
-	public abstract void Execute(ImageState[] imageAttachments, Memory<byte>[] bufferAttachments, Span<byte> input, Span<byte> output);
+        public abstract void Execute(ImageState[] imageAttachments, Memory<byte>[] bufferAttachments, Span<byte> pushConstants, Span<byte> input, Span<byte> output);
 
 	public static string ResourceType => CreateShaderInfo.ResourceType;
 }

--- a/Mtgp.Server/IMessageConnection.cs
+++ b/Mtgp.Server/IMessageConnection.cs
@@ -67,11 +67,14 @@ namespace Mtgp.Server
 		public static async Task AddCopyBufferToImageAction(this IMessageConnection connection, ActionListHandle actionList, BufferHandle buffer, ImageFormat bufferFormat, ImageHandle image, AddCopyBufferToImageActionRequest.CopyRegion[] copyRegions)
 			=> await connection.SendAsync(new AddCopyBufferToImageActionRequest(0, actionList.Id, buffer.Id, bufferFormat, image.Id, copyRegions));
 
-		public static async Task AddCopyBufferAction(this IMessageConnection connection, ActionListHandle actionList, BufferHandle sourceBuffer, BufferHandle destinationBuffer, int sourceOffset, int destinationOffset, int size)
-			=> await connection.SendAsync(new AddCopyBufferActionRequest(0, actionList.Id, sourceBuffer.Id, destinationBuffer.Id, sourceOffset, destinationOffset, size));
+                public static async Task AddCopyBufferAction(this IMessageConnection connection, ActionListHandle actionList, BufferHandle sourceBuffer, BufferHandle destinationBuffer, int sourceOffset, int destinationOffset, int size)
+                        => await connection.SendAsync(new AddCopyBufferActionRequest(0, actionList.Id, sourceBuffer.Id, destinationBuffer.Id, sourceOffset, destinationOffset, size));
 
-		public static async Task AddRunPipelineAction(this IMessageConnection connection, ActionListHandle actionList, StringSplitPipelineHandle pipeline)
-			=> await connection.SendAsync(new AddRunPipelineActionRequest(0, actionList.Id, pipeline.Id));
+                public static async Task AddPushConstantsAction(this IMessageConnection connection, ActionListHandle actionList, byte[] data)
+                        => await connection.SendAsync(new AddPushConstantsActionRequest(0, actionList.Id, data));
+
+                public static async Task AddRunPipelineAction(this IMessageConnection connection, ActionListHandle actionList, StringSplitPipelineHandle pipeline)
+                        => await connection.SendAsync(new AddRunPipelineActionRequest(0, actionList.Id, pipeline.Id));
 
 		public static async Task AddTriggerActionListAction(this IMessageConnection connection, ActionListHandle actionList, ActionListHandle triggeredActionList)
 			=> await connection.SendAsync(new AddTriggerActionListActionRequest(0, actionList.Id, triggeredActionList.Id));

--- a/Mtgp.Shader.Tsl/ShaderCompiler.cs
+++ b/Mtgp.Shader.Tsl/ShaderCompiler.cs
@@ -14,8 +14,9 @@ internal enum PartType
 	Struct,
 	Func,
 	Uniform,
-	Image,
-	ReadBuffer,
+        Image,
+        PushConstant,
+        ReadBuffer,
 	WriteBuffer,
 	Var,
 	Identifier,
@@ -108,8 +109,9 @@ public class ShaderCompiler
 														.Match(Character.EqualTo('%'), PartType.Percent)
 														.Match(Span.EqualTo("struct"), PartType.Struct)
 														.Match(Span.EqualTo("func"), PartType.Func)
-														.Match(Span.EqualTo("uniform"), PartType.Uniform)
-														.Match(Span.EqualTo("image1d"), PartType.Image)
+                                                                               .Match(Span.EqualTo("uniform"), PartType.Uniform)
+                                                                               .Match(Span.EqualTo("pushConstant"), PartType.PushConstant)
+                                                                               .Match(Span.EqualTo("image1d"), PartType.Image)
 														.Match(Span.EqualTo("image2d"), PartType.Image)
 														.Match(Span.EqualTo("var"), PartType.Var)
 														.Match(Float, PartType.DecimalLiteral)
@@ -186,10 +188,11 @@ public class ShaderCompiler
 																						   select (TopLevelDefinition)new FuncDefinition(type, name, parameters, statements);
 
 	private readonly static TokenListParser<PartType, TopLevelDefinition> bindingDefinition = from decoration in decoration
-																							  from typeKeyword in Token.EqualTo(PartType.Uniform)
-																													.Or(Token.EqualTo(PartType.Image))
-																													.Or(Token.EqualTo(PartType.ReadBuffer))
-																													.Or(Token.EqualTo(PartType.WriteBuffer))
+ from typeKeyword in Token.EqualTo(PartType.Uniform)
+                                                                               .Or(Token.EqualTo(PartType.Image))
+                                                                               .Or(Token.EqualTo(PartType.ReadBuffer))
+                                                                               .Or(Token.EqualTo(PartType.WriteBuffer))
+                                                                               .Or(Token.EqualTo(PartType.PushConstant))
 																							  from type in typeReference
 																							  from name in BaseParsers.Identifier
 																							  from lineEnd in Token.EqualTo(PartType.Semicolon)
@@ -382,13 +385,14 @@ public class ShaderCompiler
 		{
 			var type = GetType(binding.Type);
 
-			var (storage, dimension) = binding.BindingType switch
-			{
-				"uniform" => (ShaderStorageClass.Uniform, 1),
-				"image1d" => (ShaderStorageClass.Image, 1),
-				"image2d" => (ShaderStorageClass.Image, 2),
-				_ => throw new Exception($"Unknown binding type: {binding.BindingType}")
-			};
+                        var (storage, dimension) = binding.BindingType switch
+                        {
+                                "uniform" => (ShaderStorageClass.Uniform, 1),
+                                "image1d" => (ShaderStorageClass.Image, 1),
+                                "image2d" => (ShaderStorageClass.Image, 2),
+                                "pushConstant" => (ShaderStorageClass.PushConstant, 1),
+                                _ => throw new Exception($"Unknown binding type: {binding.BindingType}")
+                        };
 
 			if (storage == ShaderStorageClass.Image)
 			{

--- a/Mtgp/Messages/AddPushConstantsActionRequest.cs
+++ b/Mtgp/Messages/AddPushConstantsActionRequest.cs
@@ -1,0 +1,7 @@
+namespace Mtgp.Messages;
+
+public record AddPushConstantsActionRequest(int Id, int ActionList, byte[] Data)
+    : MtgpRequest(Id), IMtgpRequestType
+{
+    public static string Command => "core.shader.addPushConstantsAction";
+}

--- a/Mtgp/Shader/ShaderStorageClass.cs
+++ b/Mtgp/Shader/ShaderStorageClass.cs
@@ -2,10 +2,11 @@
 
 public enum ShaderStorageClass
 {
-	Input,
-	Output,
-	Uniform,
-	UniformConstant,
-	Image,
-	Function
+        Input,
+        Output,
+        PushConstant,
+        Uniform,
+        UniformConstant,
+        Image,
+        Function
 }


### PR DESCRIPTION
## Summary
- extend shader storage classes with `PushConstant`
- implement push constant parsing in shader compiler
- expose push constant actions and request
- wire push constants through pipelines and executors
- update unit tests and message utilities

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68661925c1f483279bd03938bc2444ff